### PR TITLE
FC005 example should use normal braces

### DIFF
--- a/rules.yml
+++ b/rules.yml
@@ -134,7 +134,7 @@ rules:
           not suitable for 'rolling up' into a loop.
         code: |
           # It's shorter to do this
-          %w{erlang-base erlang-corba erlang-crypto rabbitmq-server}.each do |pkg|
+          %w(erlang-base erlang-corba erlang-crypto rabbitmq-server).each do |pkg|
             package pkg do
               action :upgrade
             end


### PR DESCRIPTION
Example should use normal braces as otherwise we break rubocop rule: `Style/PercentLiteralDelimiters: %w-literals should be delimited by ( and ).`

This commit changes us to be in line with the rubocop rule in our example